### PR TITLE
feat: Transform @benchmark decorator into universal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ class Example {
 ---- | --------- | ------ | ------------- | -----------
 `metric` | `false` | `['s', 'ms', 'ns']` | `'ms'` | Metric to be used when logging function runtime
 `precision` | `false` | `number, n > 1` | `undefined` | Number of digits after comma. Passing `undefined` will print an abruptly long string.
-`stream` | `true` | `NodeJS.WritableStream` | `process.stdout` | Destination for the log to be written to. [Detailed Explanation](https://nodejs.org/api/stream.html#stream_writable_streams)
-
+`stream` | `true` | `NodeJS.WritableStream` | `process.stdout` | Destination for the log to be written to. [Detailed Explanation](https://nodejs.org/api/stream.html#stream_writable_streams). This option is **ONLY** available on NodeJS environment.
 ## `@timeout`
 
 **Decorator Type**: Method decorator

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -1,5 +1,4 @@
-import { Console } from 'console';
-import { performance } from 'perf_hooks';
+import { isNode, isBrowser } from './utils';
 
 /**
  * Apply simple benchmarking to a method,
@@ -26,7 +25,20 @@ export function benchmark(
       );
     }
 
-    const logger = new Console({ stdout: stream });
+    let logger: Console;
+    let performance: Performance;
+
+    if (isNode) { // node environment
+      const Console = require('console').Console;
+
+      logger = new Console({ stdout: stream });
+      performance = require('perf_hooks').performance;
+    } else if (isBrowser) { // browser
+      logger = window.console;
+      performance = window.performance;
+    } else { // do nothing, for now
+      return;
+    }
 
     const fn: Function = descriptor.value;
 

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -36,6 +36,14 @@ export function benchmark(
     } else if (isBrowser) { // browser
       logger = window.console;
       performance = window.performance;
+
+      // if stream is somehow defined, ignore it
+      if (stream) {
+        logger.warn(
+          /* eslint-disable-next-line */
+          'The `stream` option only available on Node.JS environment. This option will be ignored.',
+        );
+      }
     } else { // do nothing, for now
       return;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+export const isNode = typeof process !== undefined &&
+  process.versions != null &&
+  process.versions.node != null;
+
+export const isBrowser = typeof document !== undefined &&
+  typeof window !== undefined;


### PR DESCRIPTION
## Overview

This _pull request_ transforms the `@benchmark` decorator into a universal code, which means it can be used on both browser and NodeJS environment.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.4-canary.3.af4835fca9cd0c1c8789968bce33833cfbd510ad.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/decora@1.0.4-canary.3.af4835fca9cd0c1c8789968bce33833cfbd510ad.0
  # or 
  yarn add @namchee/decora@1.0.4-canary.3.af4835fca9cd0c1c8789968bce33833cfbd510ad.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
