### PR TITLE
feat: Add @bind decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![NPM Badge](https://img.shields.io/npm/v/@namchee/decora)](https://www.npmjs.com/package/@namchee/decora)
 
-Useful ECMAScript decorator for personal purposes. Compatible with both browser and NodeJS environment.
+Useful ECMAScript decorator for any development needs. Compatible with both browser and NodeJS environment.
 
-Although it's written in [TypeScript](https://www.typescriptlang.org/), these decorators should be compatible with normal JS files as long as it supports ES7.
+Although it's written in [TypeScript](https://www.typescriptlang.org/), these decorators should be compatible with normal JS files as long as the environment support ES7 standard.
 
 Will be updated indefinitely.
 
@@ -15,6 +15,13 @@ Will be updated indefinitely.
 ### TypeScript
 
 Remember to toggle the `experimentalDecorators` option to `true` in your `tsconfig.json`
+
+```json
+{
+  // ...
+  "experimentalDecorators": true
+}
+```
 
 ### JavaScript
 
@@ -67,3 +74,28 @@ class Example {
 ---- | --------- | ------ | ------------- | -----------
 `time` | `true` | `number` | `-` | Time limit for the function
 `metric` | `false` | `['s', 'ms', 'ns']` | `'ms'` | Metric to be used when logging function runtime
+
+## `@bind`
+
+**Decorator Type**: Method decorator
+
+Binds a class method to a `this` context.
+
+```ts
+class Example {
+  value = 5;
+
+  @bind()
+  bindedMethod() {
+    return this.value;
+  }
+}
+
+const value = new Example().bindedMethod(); // will return `5` instead of `undefined`
+```
+
+### Parameters
+
+**Name** | **Required?** | **Values** | **Default Value** | **Description**
+---- | --------- | ------ | ------------- | -----------
+`context` | `false` | `any` | `this` | Method's execution context

--- a/__tests__/benchmark.test.ts
+++ b/__tests__/benchmark.test.ts
@@ -41,11 +41,11 @@ describe('@benchmark', () => {
         new Test();
 
         throw new Error(
-          'Test should fail as the decorator is not applied to a function',
+          'Test should fail as the decorator is not applied to a class method',
         );
       } catch (err) {
         expect((err as Error).message)
-          .toBe('@benchmark decorator can only be applied to functions');
+          .toBe('@benchmark decorator can only be applied to class methods');
       }
     },
   );

--- a/__tests__/bind.test.ts
+++ b/__tests__/bind.test.ts
@@ -1,0 +1,35 @@
+import { bind } from '../src/bind';
+
+describe('@bind', function() {
+  it('should throw an error when applied to non-function property', function() {
+    try {
+      class Test {
+        @bind()
+        test: number = 5;
+      }
+
+      new Test();
+
+      throw new Error(
+        'Should throw an error as it is binded to a non-function property',
+      );
+    } catch (err) {
+      expect(err.message).toBe('@bind can only be applied to class methods');
+    }
+  });
+
+  it('should bind values correctly', function() {
+    class Test {
+      value = 1;
+
+      @bind()
+      test() {
+        return this.value;
+      }
+    }
+
+    const returnValue = new Test().test();
+
+    expect(returnValue).toBe(1);
+  });
+});

--- a/__tests__/bind.test.ts
+++ b/__tests__/bind.test.ts
@@ -32,4 +32,23 @@ describe('@bind', function() {
 
     expect(returnValue).toBe(1);
   });
+
+  it('should binds to custom context when parameter is provided', function() {
+    const context = {
+      value: 2,
+    };
+
+    class Test {
+      value = 1;
+
+      @bind(context)
+      test() {
+        return this.value;
+      }
+    }
+
+    const value = new Test().test();
+
+    expect(value).toBe(2);
+  });
 });

--- a/__tests__/timeout.test.ts
+++ b/__tests__/timeout.test.ts
@@ -32,7 +32,7 @@ describe('@timeout', () => {
         );
       } catch (err) {
         expect((err as Error).message)
-          .toBe('@timeout decorator can only be applied to functions');
+          .toBe('@timeout decorator can only be applied to class methods');
       }
     });
 

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -21,7 +21,7 @@ export function benchmark(
   ): void {
     if (!descriptor || !(descriptor.value instanceof Function)) {
       throw new Error(
-        '@benchmark decorator can only be applied to functions',
+        '@benchmark decorator can only be applied to class methods',
       );
     }
 

--- a/src/bind.ts
+++ b/src/bind.ts
@@ -1,0 +1,24 @@
+/**
+ * Binds method context with the provided reference
+ *
+ * @param {Object?} reference - method's context. Default to `this`
+ */
+export function bind(reference?: Object): Function {
+  return function(
+    target: Object,
+    keyName: string,
+    descriptor: PropertyDescriptor,
+  ): Object {
+    if (!descriptor || !(descriptor.value instanceof Function)) {
+      throw new Error('@bind can only be applied to class methods');
+    }
+
+    return {
+      get() {
+        const that = reference || this;
+
+        return (descriptor.value as Function).bind(that);
+      },
+    };
+  };
+}

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -18,7 +18,7 @@ export function timeout(
   ) {
     if (!descriptor || !(descriptor.value instanceof Function)) {
       throw new Error(
-        '@timeout decorator can only be applied to functions',
+        '@timeout decorator can only be applied to class methods',
       );
     }
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -31,7 +31,7 @@
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": false,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": false,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
## Overview

This pull request adds `@bind`, which will bind a class method to any provided context. Defaults to `this`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.6-canary.5.7abed64c3298dddb802e0a3f129d839c1857414e.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @namchee/decora@1.0.6-canary.5.7abed64c3298dddb802e0a3f129d839c1857414e.0
  # or 
  yarn add @namchee/decora@1.0.6-canary.5.7abed64c3298dddb802e0a3f129d839c1857414e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
